### PR TITLE
chore: expand npm keywords for discoverability (categories)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,13 @@
         "node-red",
         "mjml",
         "email",
-        "mjml-parse"
+        "mjml-parse",
+        "html-email",
+        "email-template",
+        "responsive-email",
+        "template",
+        "mustache",
+        "parser"
     ],
     "author": "André Lademann <vergissberlin@googlemail.com>",
     "contributors": [


### PR DESCRIPTION
## Summary

- Expand `package.json` `keywords` with category-style terms (`html-email`, `email-template`, `responsive-email`, `template`, `mustache`, `parser`) so the package surfaces under more relevant searches on npm and the [Node-RED Flow Library](https://flows.nodered.org).
- Verified the editor palette category is already correctly set: `mjml-parse/mjml-parse.html` registers the node with `category: 'parser'`, which is one of Node-RED's built-in default palette categories (see the commented `categories` list in `test/fixtures/settings.js`). No change needed there.

## Not covered by this PR

GitHub repository topics (e.g. `node-red`, `mjml`, `email`) are repo-level metadata, not part of the codebase, so they aren't set here. Suggested topics to add manually under repo Settings → General → Topics: `node-red`, `mjml`, `email`, `html-email`, `email-template`, `parser`, `mustache`.

## Test plan

- [x] `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"` — valid JSON
- [x] No functional/runtime code changed; existing test suite unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_01JWMNa3SMHSitUZ9A2m9Fuf)_