### PR TITLE
chore(engines): pnpm support + minimum Node.js version alignment

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
@@ -28,8 +26,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
       - run: pnpm config set node-linker hoisted
@@ -28,7 +28,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
       - run: pnpm config set node-linker hoisted

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # node-red@2.x + node-red-node-test-helper are exercised here; Node 24+ can break older stacks.
-        node-version: ['20.x', '22.x']
+        # engines.node requires >=22.9 (matches latest node-red release's own minimum); Node 24+ can break older stacks.
+        node-version: ['22.x']
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ This guide explains how to:
 
 ## Prerequisites
 
-- Node.js 20+
+- Node.js 22.9+ (matches the minimum required by the latest Node-RED release)
 - pnpm 10+
 - Git
 
@@ -102,7 +102,7 @@ This runs Mocha on `test/**/*_spec.js`, including:
 
 The `devDependency` on `node-red` pins the version used by `node-red-node-test-helper`. After changing editor or admin HTTP behavior, also smoke-test on Node-RED 3.x/4.x (Monaco default) if you can.
 
-GitHub Actions runs tests on **Node.js 20.x and 22.x** (see `.github/workflows/pull-request.yml`). Newer Node majors may require upgrading `node-red` / `node-red-node-test-helper` before adding them to the matrix.
+GitHub Actions runs tests on **Node.js 22.x** (see `.github/workflows/pull-request.yml`), matching the `engines.node` floor (`>=22.9.0`). That floor tracks the minimum Node.js version required by the latest Node-RED release itself — bump it (and the matrix) when a newer Node-RED major raises its own minimum. Newer Node majors (e.g. 24.x) may still require upgrading `node-red` / `node-red-node-test-helper` before adding them to the matrix.
 
 The browser editor (Monaco/Ace) is not covered by automated tests here; validate that in the manual checklist below.
 

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
     "funding": "https://www.paypal.com/paypalme/vergissberlin",
     "repository": "https://github.com/vergissberlin/node-red-contrib-mjml",
     "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.0.0",
+        "pnpm": ">=10.0.0"
     },
+    "packageManager": "pnpm@10.33.0",
     "bugs": {
         "url": "https://github.com/vergissberlin/node-red-contrib-mjml/issues"
     },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "funding": "https://www.paypal.com/paypalme/vergissberlin",
     "repository": "https://github.com/vergissberlin/node-red-contrib-mjml",
     "engines": {
-        "node": ">=20.0.0",
+        "node": ">=22.9.0",
         "pnpm": ">=10.0.0"
     },
     "packageManager": "pnpm@10.33.0",


### PR DESCRIPTION
## Summary

- `engines.pnpm": ">=10.0.0"` + `"packageManager": "pnpm@10.33.0"` added so Corepack resolves the same pnpm major version already used in CI, matching `CONTRIBUTING.md` ("pnpm 10+").
- **Fix:** raised `engines.node` from `>=20.0.0` to `>=22.9.0`. Per the [Node-RED node packaging guidelines](https://nodered.org/docs/creating-nodes/packaging#minimum-nodejs-version), `engines.node` SHOULD satisfy the current minimum supported version of the latest Node-RED release — and the latest release (`node-red@5.0.4`) itself requires Node.js `>=22.9`. Node.js 20 is also now end-of-life.
- Aligned the CI matrix (`pull-request.yml`), the publish workflow (`npm-publish.yml`), and `CONTRIBUTING.md` to the new `22.x` floor so the declared minimum, the tested Node version, and the docs all agree.

## Fixes applied during review

- `pnpm/action-setup@v4` failed with "Multiple versions of pnpm specified" once both its `version: 10` input and the new `packageManager` field were present. Removed the redundant `version: 10` input from both workflows so the action reads the version from `packageManager` instead.

## Test plan

- [x] `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"` — valid JSON
- [x] YAML syntax of both workflow files validated
- [x] `pnpm install`
- [x] `pnpm test` — all 30 tests passing (locally on Node 22.22.2)