### PR TITLE
chore(ci): update GitHub Actions to latest majors

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,9 +9,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
@@ -24,9 +24,9 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,9 +11,9 @@ jobs:
         # engines.node requires >=22.9 (matches latest node-red release's own minimum); Node 24+ can break older stacks.
         node-version: ['22.x']
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.REPO_TOKEN || github.token }}
           release-type: node


### PR DESCRIPTION
## Summary

Applies the GitHub Actions version bumps flagged as rate-limited on the Renovate Dependency Dashboard ([issue #4](https://github.com/vergissberlin/node-red-contrib-mjml/issues/4)):

- `actions/checkout` v2/v4 → **v7**
- `actions/setup-node` v4 → **v7**
- `pnpm/action-setup` v4 → **v6**
- `googleapis/release-please-action` v4 → **v5**

Applied across all three workflows (`pull-request.yml`, `npm-publish.yml`, `release-please.yml`).

## Test plan

- [x] YAML syntax validated for all three workflow files
- [x] No `package.json`/lockfile/code changes — CI itself (running with the new action versions) is the verification for this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01JWMNa3SMHSitUZ9A2m9Fuf)_