### PR TITLE
ci(npm-publish): surface expired npm token clearly instead of a generic 404

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,5 +1,7 @@
 # Publishes to npm when a GitHub release is created (e.g. by merging the release-please PR).
 # Set NPM_TOKEN in repository secrets (npm token with publish access).
+# npm granular access tokens expire (90 days by default) - if publish fails with a 404 on
+# an existing package, the token has likely expired and needs to be rotated.
 name: Publish Package to npmjs
 on:
   release:
@@ -31,6 +33,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
       - run: pnpm install
+      - name: Verify npm authentication
+        run: npm whoami --registry=https://registry.npmjs.org
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm publish --access=public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The v1.3.1 [publish run](https://github.com/vergissberlin/node-red-contrib-mjml/actions/runs/31336649318/job/93303553959) failed:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@vergissberlin%2fnode-red-contrib-mjml
npm error 404  '@vergissberlin/node-red-contrib-mjml@1.3.1' is not in this registry.
```

I verified the package **does exist** on the npm registry (latest published version is 1.3.0, from the last successful run of this workflow in March). A 404 on `PUT` for a package that already exists is npm's signature for an **invalid or expired auth token**, not a missing/first-publish package. Nothing in the workflow or `package.json` changed since the last successful publish, and the ~5 month gap lines up with npm's default 90-day expiration on granular access tokens.

**This PR does not fix the root cause** — that requires generating a new npm token for the `@vergissberlin` scope and updating the `NPM_TOKEN` repository secret, which needs npmjs.com + GitHub settings access I don't have. It adds a preflight check so this failure mode is unambiguous next time instead of a confusing 404:

- Add an `npm whoami` step before `npm publish` in `.github/workflows/npm-publish.yml`, so an expired/invalid `NPM_TOKEN` fails immediately with a clear authentication error.
- Add a comment noting the 90-day token expiration as the likely cause of a 404-on-existing-package failure.

## Action needed (outside this PR)

Rotate `NPM_TOKEN` in repo Settings → Secrets and variables → Actions with a fresh npm automation token, then re-run the v1.3.1 release workflow.

## Test plan

- [x] Reviewed workflow YAML for syntax correctness
- [ ] Confirm `npm whoami` step passes once `NPM_TOKEN` is rotated
- [ ] Re-run the v1.3.1 publish workflow to confirm the release completes

---
_Generated by [Claude Code](https://claude.ai/code/session_01M29ti7nmYrrpKW3Jpc7dJr)_